### PR TITLE
Fix Calculator Buttons

### DIFF
--- a/script.js
+++ b/script.js
@@ -87,7 +87,7 @@ function handleNum(digit) {
 }
 
 function init() {
-    document.querySelector("calc-buttons").addEventListener('click', function(event) {
+    document.querySelector(".calc-buttons").addEventListener('click', function(event) {
         buttonClick(event.target.innerText);
     })
 }


### PR DESCRIPTION
"calc-buttons" is not semantically correct here. Use ".calc-buttons"

Due to an incorrect `querySelector` class name, the buttons did not properly
get an event listener attached to them. By resolving this issue, the buttons
now respond appropriately.


Here's the error (from my browser's javascript console window):
```
Uncaught TypeError: Cannot read properties of null (reading 'addEventListener')
    at init (script.js:90:43)
    at script.js:106:1
```

When you get an error saying something along the lines of "cannot read ... of
null" this usually means that you are invoking a function on a null object
which doesn't exist. A `querySelector` call that returns null is a good sign
that your DOM (HTML Document) has no such element to be selected (which means
you gave `querySelector` a bad selection).


My fix is included in this PR, please review and merge once ready/tested :)
